### PR TITLE
Check node environment explicitly before checking browser environment

### DIFF
--- a/lib/MagicPen.js
+++ b/lib/MagicPen.js
@@ -31,14 +31,14 @@ function MagicPen(options) {
     }
 }
 
-if (typeof window !== 'undefined' && typeof window.navigator !== 'undefined') {
+if (typeof exports === 'object' && typeof exports.nodeName !== 'string' && require('supports-color')) {
+    MagicPen.defaultFormat = 'ansi'; // colored console
+} else if (typeof window !== 'undefined' && typeof window.navigator !== 'undefined') {
     if (window.mochaPhantomJS || (window.__karma__ && window.__karma__.config.captureConsole)) {
         MagicPen.defaultFormat = 'ansi'; // colored console
     } else {
         MagicPen.defaultFormat = 'html'; // Browser
     }
-} else if (require('supports-color')) {
-    MagicPen.defaultFormat = 'ansi'; // colored console
 } else {
     MagicPen.defaultFormat = 'text'; // Plain text
 }


### PR DESCRIPTION
Avoids false positive browser detection when jsdom leaks window global.

When running tests in the Podio code base we had this scenario in a few places:

```js
var jsdomify = require('jsdomify');
jsdomify.create(); // Leaks window and other browser emulating things into global scope

expect = require('unexpected').clone();
expect.installPlugin(require('unexpected-dom'));
expect.installPlugin(require('unexpected-sinon'));
expect.output.installPlugin(require('magicpen-prism'));
```

In this example magicpen thinks it's in a browser environment because of the leaked `window`. This PR changes the order to more explicitly test for a node environment before probing for browser stuff