### PR TITLE
Updated supports-color package, using better detection fidelity.

### DIFF
--- a/lib/AnsiSerializer.js
+++ b/lib/AnsiSerializer.js
@@ -14,6 +14,7 @@ Object.keys(ansiStyles).forEach(function (styleName) {
 
 function AnsiSerializer(theme) {
     this.theme = theme;
+    this.supportsColor = require('supports-color') || {};
 }
 
 AnsiSerializer.prototype = new TextSerializer();
@@ -127,7 +128,7 @@ AnsiSerializer.prototype.text = function (options) {
 
                 var open = ansiStyles[styleName].open;
                 var close = ansiStyles[styleName].close;
-                if (color16Hex !== color256Hex) {
+                if (this.supportsColor.has256) {
                     open += '\x1b[' + (isBackgroundColor ? 48 : 38) + ';5;' + closest256ColorIndex + 'm';
                 }
                 if (cacheSize < maxColorCacheSize) {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "istanbul": "0.3.17",
     "jshint": "*",
     "mocha": "1.20.1",
+    "proxyquire": "^1.7.10",
     "sinon": "1.9.1",
     "unexpected": "9.5.0",
     "unexpected-sinon": "6.4.2"
@@ -33,7 +34,7 @@
   "dependencies": {
     "ansi-styles": "2.0.0",
     "color-diff": "0.1.7",
-    "supports-color": "1.2.0"
+    "supports-color": "^3.1.2"
   },
   "license": "MIT"
 }

--- a/test/magicpen.spec.js
+++ b/test/magicpen.spec.js
@@ -1,5 +1,10 @@
 /*global describe, it, beforeEach*/
-var magicpen = require('..');
+var proxyquire = require('proxyquire');
+var magicpen = proxyquire('..', {
+    './AnsiSerializer': proxyquire('../lib/AnsiSerializer', {
+        'supports-color': { hasBasic: true, has256: true, has16m: true, level: 3 }
+    })
+});
 var expect = require('unexpected');
 var sinon = require('sinon');
 expect.use(require('unexpected-sinon'));


### PR DESCRIPTION
There's some basis for refactoring the code based on the capabilities that `supports-color` now has.

Tests mock it out as a 256-color capable terminal.
