### PR TITLE
Upgrade supports-color (Major)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: node_js
 node_js:
-  - "0.10"
-  - "0.12"
+  - "6"
+  - "7"
+  - "8.4.0"
+  - "9"
+  - "10"
+
 script: "npm run-script travis"

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "ansi-styles": "2.0.0",
     "color-diff": "0.1.7",
-    "supports-color": "1.2.0"
+    "supports-color": "6.1.0"
   },
   "license": "MIT"
 }


### PR DESCRIPTION
To get correct color detection in the newest version of Jest.

Bumped Node version support to 6 and above.