### PR TITLE
Avoid querying Deno.permissions

### DIFF
--- a/lib/platform.js
+++ b/lib/platform.js
@@ -3,7 +3,15 @@ var isNode = !!(typeof process !== 'undefined' && process.versions && process.ve
 
 module.exports = (function () {
     if (typeof Deno !== 'undefined') {
-        var env = Deno.permissions().env ? Deno.env() : {};
+        var env = {};
+        try {
+            env = Deno.env();
+        } catch (err) {
+          // Probably a permissions error because we don't have permission to read the environment variables
+          // Unfortunately the whole permissions API is async now:
+          // https://github.com/denoland/deno/pull/3200/files
+          // ... so we can't detect whether we do have access
+        }
 
         return {
             argv: Deno.args,


### PR DESCRIPTION
Context: https://github.com/unexpectedjs/unexpected/pull/667

Unfortunately the whole permissions API is async now: https://github.com/denoland/deno/pull/3200/files
... so we can't detect whether we do have access